### PR TITLE
Add additional EnvironmentIdentifier parameter and clean up stack resources no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The easiest deployment of this solution is using AWS SAM
     * SlackChannel - slack Channel to send notifications to
     * SlackWebhookUrl - slack webhook url for the above channel
     * DomainNameList - comma separated list of OS domain names to monitor
+    * EnvironmentIdentifier - optional environment identifier (e.g. prod/stage) - if not supplied, "default" will be used
 * deploy the lambda using SAM: `./utils/deploy.sh default`
 
 This will deploy/update the lambda.

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -11,5 +11,6 @@ capabilities = "CAPABILITY_NAMED_IAM"
 parameter_overrides = [
   "SlackChannel=<CHANNEL_NAME>",
   "SlackWebhookUrl=<HOOK_URL>",
-  "DomainNameList=<COMMA_SEPARATED_LIST_OF_OS_DOMAINS>"
+  "DomainNameList=<COMMA_SEPARATED_LIST_OF_OS_DOMAINS>",
+  "EnvironmentIdentifier=<ENV_ID>"
 ]

--- a/template.yaml
+++ b/template.yaml
@@ -12,51 +12,15 @@ Parameters:
   DomainNameList:
     Type: String
     Default: ""
+  EnvironmentIdentifier:
+    Type: String
+    Default: "default"
 
 Resources:
-  ExecutionRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          -
-            Effect: "Allow"
-            Principal:
-              Service:
-                - "lambda.amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
-      Path: /
-      Policies:
-      - PolicyDocument:
-          Statement:
-          - Action:
-            - logs:CreateLogGroup
-            - logs:CreateLogStream
-            - logs:PutLogEvents
-            - logs:DescribeLogStreams
-            Effect: Allow
-            Resource:
-            - '*'
-          - Action:
-            - "cloudformation:ListStacks"
-            - "cloudformation:DeleteStack"
-            - "iam:DeleteRolePolicy"
-            - "iam:DeleteRole"
-            - "ec2:DescribeInstances"
-            - "es:DescribeElasticsearchDomain"
-            - "es:GetCompatibleElasticsearchVersions"
-            Effect: Allow
-            Resource:
-            - '*'
-          Version: "2012-10-17"
-        PolicyName: "AllowLogsandCloudformation"
-
-  esServiceUpdater:
+  osServiceUpdater:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: OS-Service-Update-Notifier
+      FunctionName: !sub "OS-Service-Update-Notifier-${EnvironmentIdentifier}"
       Description: Lambda function which will alert a slack channel when there is an update available for an opensearch cluster
       Handler: es_service_updater.lambda_handler
       Runtime: python3.13

--- a/template.yaml
+++ b/template.yaml
@@ -20,7 +20,7 @@ Resources:
   osServiceUpdater:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !sub "OS-Service-Update-Notifier-${EnvironmentIdentifier}"
+      FunctionName: !Sub "OS-Service-Update-Notifier-${EnvironmentIdentifier}"
       Description: Lambda function which will alert a slack channel when there is an update available for an opensearch cluster
       Handler: es_service_updater.lambda_handler
       Runtime: python3.13


### PR DESCRIPTION
If you want to have multiple lambdas in the same account and region, they will need to have unique identifier, so an optional "EnvironmentIdentifier" is being added.

Also removed now unnecessary resources (role, policy) that are included in the serverless function definition.